### PR TITLE
Add steps to get CRN sites & download some example data

### DIFF
--- a/1_fetch.yml
+++ b/1_fetch.yml
@@ -3,19 +3,38 @@ target_default: 1_fetch
 packages:
   - dataRetrieval
   - dplyr
+  - sf
 
 sources:
   - 1_fetch/src/fetch_nwis.R
+  - 1_fetch/src/fetch_gwcrn.R
 
 targets:
 
   1_fetch:
     depends:
       - 1_fetch/out/gw_data.rds
+      - 1_fetch/out/gw_crn_data.rds
 
+##-- All GW sites with continuous data --##
   
   gw_sites:
     command: fetch_gw_sites(start_date, end_date, gw_param_cd)
   gw_site_info:
     command: fetch_gw_site_info(gw_sites)
   1_fetch/out/gw_data.rds:
+    command: fetch_gw_data(target_name, gw_sites, start_date, end_date, gw_param_cd, stat_cd = I("00003"), 200)
+  
+##-- Climate Response Network sites --##
+  
+  1_fetch/tmp/gw_crn_sites.zip:
+    command: download.file(
+      destfile = target_name,
+      url = I('https://groundwaterwatch.usgs.gov/dws_maps/covers/shapefiles/crn_wells.zip'))
+  gw_crn_sites_sf:
+    command: unzip_and_read_shp(zipfile = '1_fetch/tmp/gw_crn_sites.zip', tmp_dir = I('1_fetch/tmp'))
+  gw_crn_sites:
+    command: extract_crn_sites(gw_crn_sites_sf)
+  
+  1_fetch/out/gw_crn_data.rds:
+    command: fetch_gw_data(target_name, gw_crn_sites, start_date, end_date, gw_param_cd, stat_cd = I("00001"), 200)

--- a/1_fetch.yml
+++ b/1_fetch.yml
@@ -11,21 +11,11 @@ targets:
 
   1_fetch:
     depends:
-      - gw_sites
-      - 1_fetch/out/gw_site_info.rds
       - 1_fetch/out/gw_data.rds
 
-  1_fetch/out/gw_sites.rds:
-    command: fetch_gw_sites(target_name, start_date, end_date, gw_param_cd)
+  
   gw_sites:
-    command: readRDS('1_fetch/out/gw_sites.rds')
-  
-  1_fetch/out/gw_site_info.rds:
-    command: fetch_gw_site_info(target_name, gw_sites)
+    command: fetch_gw_sites(start_date, end_date, gw_param_cd)
   gw_site_info:
-    command: readRDS('1_fetch/out/gw_site_info.rds')
-  
+    command: fetch_gw_site_info(gw_sites)
   1_fetch/out/gw_data.rds:
-    command: fetch_gw_data(target_name, gw_sites, start_date, end_date, gw_param_cd, 200)
-  gw_data:
-    command: readRDS('1_fetch/out/gw_data.rds')

--- a/1_fetch/src/fetch_gwcrn.R
+++ b/1_fetch/src/fetch_gwcrn.R
@@ -1,0 +1,12 @@
+unzip_and_read_shp <- function(zipfile, tmp_dir) {
+  # Unzip the shapefile zip
+  fns <- unzip(zipfile = zipfile, overwrite = TRUE, exdir = tmp_dir)
+  
+  # Read and return an sf object of the shapefile
+  st_read(fns[grep(".shp", fns)])
+}
+
+extract_crn_sites <- function(gwcrn_sf) {
+  # The site ids are read in as factors in st_read
+  gwcrn_sf %>% pull(SITEID) %>% levels()
+}

--- a/1_fetch/src/fetch_gwcrn.R
+++ b/1_fetch/src/fetch_gwcrn.R
@@ -8,5 +8,5 @@ unzip_and_read_shp <- function(zipfile, tmp_dir) {
 
 extract_crn_sites <- function(gwcrn_sf) {
   # The site ids are read in as factors in st_read
-  gwcrn_sf %>% pull(SITEID) %>% levels()
+  gwcrn_sf %>% pull(SITEID) %>% unique()
 }

--- a/1_fetch/src/fetch_nwis.R
+++ b/1_fetch/src/fetch_nwis.R
@@ -1,5 +1,5 @@
 #' Fetch all NWIS sites that have groundwater level data during the appropriate time period
-fetch_gw_sites <- function(filename, start_date, end_date, param_cd){
+fetch_gw_sites <- function(start_date, end_date, param_cd){
   
   hucs <- zeroPad(1:21, 2) # all hucs
   
@@ -19,13 +19,12 @@ fetch_gw_sites <- function(filename, start_date, end_date, param_cd){
     ) %>% c(sites)
   }
   
-  saveRDS(sites, filename)
+  return(sites)
 }
 
-fetch_gw_site_info <- function(filename, sites) {
+fetch_gw_site_info <- function(sites) {
   readNWISsite(sites) %>% 
-    select(site_no, station_nm, state_cd, dec_lat_va, dec_long_va) %>% 
-    saveRDS(filename)
+    select(site_no, station_nm, state_cd, dec_lat_va, dec_long_va)
 }
 
 fetch_gw_data <- function(filename, sites, start_date, end_date, param_cd, request_limit = 10) {

--- a/1_fetch/src/fetch_nwis.R
+++ b/1_fetch/src/fetch_nwis.R
@@ -27,7 +27,7 @@ fetch_gw_site_info <- function(sites) {
     select(site_no, station_nm, state_cd, dec_lat_va, dec_long_va)
 }
 
-fetch_gw_data <- function(filename, sites, start_date, end_date, param_cd, request_limit = 10) {
+fetch_gw_data <- function(filename, sites, start_date, end_date, param_cd, stat_cd, request_limit = 10) {
   
   # Number indicating how many sites to include per dataRetrieval request to prevent
   # errors from requesting too much at once. More relevant for surface water requests.
@@ -46,10 +46,9 @@ fetch_gw_data <- function(filename, sites, start_date, end_date, param_cd, reque
         startDate = start_date,
         endDate = end_date,
         parameterCd = param_cd,
-        statCd = "00003") %>%
-      renameNWISColumns() %>% 
-      # WLBLS = "Water level below surface"
-      select(site_no, Date, GWL = WLBLS), 
+        statCd = stat_cd) %>%
+      rename(GWL := sprintf("X_%s_%s", param_cd, stat_cd)) %>% 
+      select(site_no, Date, GWL), 
       # no data returned situation
       error = function(e) return()
     )

--- a/2_process.yml
+++ b/2_process.yml
@@ -17,7 +17,7 @@ targets:
   
   # Add site info to gw_data
   gw_data_w_site_info:
-    command: add_site_info(gw_data, gw_site_info)
+    command: add_site_info('1_fetch/out/gw_data.rds', gw_site_info)
   
   # Summarize GWL data
   gw_change_last_7_days:

--- a/2_process/src/process_nwis_data.R
+++ b/2_process/src/process_nwis_data.R
@@ -1,6 +1,6 @@
 
-add_site_info <- function(gw_data, gw_site_info) {
-  gw_data %>% 
+add_site_info <- function(gw_data_fn, gw_site_info) {
+  readRDS(gw_data_fn) %>% 
     left_join(gw_site_info) %>% 
     left_join(select(stateCd, -STATENS), by = c("state_cd" = "STATE")) %>% 
     rename(state = STUSAB)

--- a/README.md
+++ b/README.md
@@ -13,3 +13,11 @@ To build, check the `start_date` and `end_date` in `0_config.yml`. Then, run the
 library(scipiper)
 scmake()
 ```
+
+### How to get Climate Response Network data:
+
+```r
+library(scipiper)
+scmake("1_fetch/out/gw_crn_data.rds")
+crn_data <- readRDS("1_fetch/out/gw_crn_data.rds")
+```


### PR DESCRIPTION
Updated the pipeline to include steps to pull down [Climate Response Network](https://groundwaterwatch.usgs.gov/CRNHome.asp) sites and corresponding data. To use this pipeline and get data to play with, change the dates in `0_config.yml` to the time period you would like and run the following:

```r
library(scipiper)
scmake("1_fetch/out/gw_crn_data.rds")
crn_data <- readRDS("1_fetch/out/gw_crn_data.rds")
```

This adds CRN sites to fetch, but nothing else. The remaining process, visualize, and animate steps are the same.

