### PR TITLE
Historic data added to pipeline

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -1,0 +1,1 @@
+Sys.setenv("AWS_DEFAULT_REGION" = 'us-west-2')

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ vignettes/*.pdf
 */out/*
 !*/out/*.ind
 .remake
+build/

--- a/0_config.yml
+++ b/0_config.yml
@@ -2,8 +2,23 @@ target_default: 0_config
 
 targets:
   
-  0_config:
-    depends:
+##-- Historic data configs --##
+
+  historic_start_date:
+    command: as.Date(I('1800-01-01'))
+  historic_end_date:
+    command: as.Date(I('2020-12-31'))
+  historic_fetch_size_limit:
+    command: I(50)
+  
+  # Building these are completely decoupled from the rest of the pipeline
+  # Use these objects in 1_fetch to s3_get the data
+  historic_site_info_s3_fn:
+    command: c(I('gw-conditions/historic_gw_site_info.rds.ind'))
+  historic_data_s3_fn:
+    command: c(I('gw-conditions/historic_gw_data.csv.ind'))
+  historic_quantiles_s3_fn:
+    command: c(I('gw-conditions/historic_gw_quantiles.csv.ind'))
   
 ##-- Fetch configs --##
   

--- a/0_config.yml
+++ b/0_config.yml
@@ -22,10 +22,10 @@ targets:
   
 ##-- Fetch configs --##
   
-  start_date:
-    command: as.Date(I('2020-11-27'))
-  end_date:
-    command: as.Date(I('2020-12-10'))
+  viz_start_date:
+    command: as.Date(I('2020-10-01'))
+  viz_end_date:
+    command: as.Date(I('2020-12-31'))
   
   gw_param_cd:
     command: c(I('72019'))
@@ -33,7 +33,7 @@ targets:
 ##-- Process configs --##
 
   date_for_pct_change:
-    command: c(end_date)
+    command: c(viz_end_date)
   proj_str:
     command: c(I('+proj=laea +lat_0=45 +lon_0=-100 +x_0=0 +y_0=0 +a=6370997 +b=6370997 +units=m +no_defs'))
 

--- a/0_historic.yml
+++ b/0_historic.yml
@@ -1,0 +1,53 @@
+target_default: 0_historic
+
+include:
+  - 0_config.yml
+
+packages:
+  - dataRetrieval
+  - tidyverse
+
+sources:
+  - 0_historic/src/do_gw_fetch.R
+  - 1_fetch/src/fetch_nwis.R
+
+targets:
+
+  0_historic:
+    depends:
+      - gw-conditions/historic_gw_site_info.rds.ind
+      - gw-conditions/historic_gw_data.csv.ind
+      # - gw-conditions/historic_gw_quantiles.csv.ind
+
+##-- All GW sites with continuous data for all time --##
+  
+  historic_gw_sites:
+    command: fetch_gw_sites(historic_start_date, historic_end_date, gw_param_cd)
+  
+  historic_gw_site_info:
+    command: fetch_gw_site_info(historic_gw_sites)
+  0_historic/out/historic_gw_site_info.rds:
+    command: saveRDS(file = target_name, historic_gw_site_info)
+  
+  0_historic/out/historic_gw_data.csv:
+    command: do_gw_fetch(
+      final_target = target_name,
+      task_makefile = I('0_historic_fetch_tasks.yml'),
+      gw_site_nums = historic_gw_sites,
+      request_limit = historic_fetch_size_limit,
+      '0_historic/src/do_gw_fetch.R')
+  
+  # INSERT QUANTILES CODE HERE
+  # 0_historic/out/historic_gw_quantiles.csv:
+  #  command: 
+  
+##-- Now push historic data and quantiles to S3 to be used in the rest of the pipeline --##
+
+  gw-conditions/historic_gw_site_info.rds.ind:
+    command: s3_put(remote_ind = target_name, local_source = '0_historic/out/historic_gw_site_info.rds')
+  
+  gw-conditions/historic_gw_data.csv.ind:
+    command: s3_put(target_name, local_source = '0_historic/out/historic_gw_data.csv')
+  
+  # gw-conditions/historic_gw_quantiles.csv.ind:
+  #  command: s3_put(target_name, local_source = '0_historic/out/historic_gw_quantiles.csv')

--- a/0_historic/src/do_gw_fetch.R
+++ b/0_historic/src/do_gw_fetch.R
@@ -1,0 +1,103 @@
+do_gw_fetch <- function(final_target, task_makefile, gw_site_nums, request_limit, ...) {
+  
+  # Number indicating how many sites to include per dataRetrieval request to prevent
+  # errors from requesting too much at once. More relevant for surface water requests.
+  req_bks <- seq(1, length(gw_site_nums), by=request_limit)
+  
+  tasks <- tibble(i_start = req_bks,
+                  i_end = req_bks + request_limit-1) %>% 
+    # fix i_end to stop at the actual last value
+    mutate(i_end = ifelse(i_end > length(gw_site_nums), length(gw_site_nums), i_end),
+           task_id = sprintf("%04d_to_%04d", i_start, i_end))
+  
+  site_sequence <- create_task_step(
+    step_name = 'site_sequence',
+    target_name = function(task_name, ...) {
+      sprintf('sites_i_%s', task_name)
+    },
+    command = function(task_name, ...) {
+      task_df <- filter(tasks, task_id == task_name)
+      sprintf("%s:%s", task_df$i_start, task_df$i_end)
+    }
+  )
+  
+  subset_sites <- create_task_step(
+    step_name = 'subset_sites',
+    target_name = function(task_name, ...) {
+      sprintf('gw_sites_%s', task_name)
+    },
+    command = function(..., task_name, steps) {
+      sprintf("historic_gw_sites[%s]", steps[["site_sequence"]]$target_name)
+    }
+  )
+  
+  download_data <- create_task_step(
+    step_name = 'download_data',
+    target_name = function(task_name, ...) {
+      sprintf("0_historic/tmp/historic_data_%s.feather", task_name)
+    },
+    command = function(..., task_name, steps) {
+      psprintf("fetch_gw_historic(",
+               "target_name = target_name,",
+               "gw_sites = %s," = steps[["subset_sites"]]$target_name,
+               "start_date = historic_start_date,",
+               "end_date = historic_end_date,",
+               "param_cd = gw_param_cd,",
+               "stat_cd = I('00003'))")
+    }
+  )
+  
+  # Create the task plan
+  task_plan <- create_task_plan(
+    task_names = tasks$task_id,
+    task_steps = list(site_sequence, subset_sites, download_data),
+    final_steps = c('download_data'),
+    add_complete = FALSE)
+  
+  # Create the task remakefile
+  create_task_makefile(
+    task_plan = task_plan,
+    makefile = task_makefile,
+    include = c('0_historic.yml'),
+    sources = c(...),
+    packages = c('tidyverse', 'dataRetrieval', 'scipiper', 'feather', 'purrr'),
+    final_targets = final_target,
+    finalize_funs = 'combine_gw_files',
+    as_promises = TRUE,
+    tickquote_combinee_objects = TRUE)
+  
+  # Build the tasks
+  loop_tasks(task_plan = task_plan,
+             task_makefile = task_makefile,
+             num_tries = 3, # Try a few times, there could be some internet flakiness
+             n_cores = 1) # Only one core! Don't want to overwhelm NWIS services
+  
+  # Clean up files created
+  
+  # Remove the temporary target from remake's DB; it won't necessarily be a unique  
+  #   name and we don't need it to persist, especially since killing the task yaml
+  scdel(sprintf("%s_promise", basename(final_target)), remake_file=task_makefile)
+  # Delete task makefile since it is only needed internally for this function and  
+  #   not needed at all once loop_tasks is complete. Also delete temporary files
+  #   saved in order to decouple task makefile from `remake.yml`.
+  file.remove(task_makefile)
+  
+}
+
+fetch_gw_historic <- function(target_name, gw_sites, start_date, end_date, param_cd, stat_cd) {
+  readNWISdv(
+    siteNumbers = gw_sites,
+    startDate = start_date,
+    endDate = end_date,
+    parameterCd = param_cd,
+    statCd = stat_cd) %>%
+    rename(GWL := sprintf("X_%s_%s", param_cd, stat_cd)) %>% 
+    select(site_no, Date, GWL) %>% 
+    write_feather(target_name)
+}
+
+combine_gw_files <- function(target_name, ...) {
+  purrr::map(list(...), function(fn) read_feather(fn)) %>% 
+    purrr::reduce(bind_rows) %>% 
+    readr::write_csv(target_name)
+}

--- a/0_historic/src/do_gw_fetch.R
+++ b/0_historic/src/do_gw_fetch.R
@@ -98,6 +98,6 @@ fetch_gw_historic <- function(target_name, gw_sites, start_date, end_date, param
 
 combine_gw_files <- function(target_name, ...) {
   purrr::map(list(...), function(fn) read_feather(fn)) %>% 
-    purrr::reduce(bind_rows) %>% 
+    bind_rows() %>% 
     readr::write_csv(target_name)
 }

--- a/1_fetch.yml
+++ b/1_fetch.yml
@@ -29,11 +29,11 @@ targets:
 ##-- GW sites and data for current viz time period --##
   
   gw_sites:
-    command: fetch_gw_sites(start_date, end_date, gw_param_cd)
+    command: fetch_gw_sites(viz_start_date, viz_end_date, gw_param_cd)
   gw_site_info:
     command: fetch_gw_site_info(gw_sites)
   1_fetch/out/gw_data.rds:
-    command: fetch_gw_data(target_name, gw_sites, start_date, end_date, gw_param_cd, stat_cd = I("00003"), 200)
+    command: fetch_gw_data(target_name, gw_sites, viz_start_date, viz_end_date, gw_param_cd, stat_cd = I("00003"), 200)
   
 ##-- Climate Response Network sites --##
   
@@ -47,4 +47,4 @@ targets:
     command: extract_crn_sites(gw_crn_sites_sf)
   
   1_fetch/out/gw_crn_data.rds:
-    command: fetch_gw_data(target_name, gw_crn_sites, start_date, end_date, gw_param_cd, stat_cd = I("00001"), 200)
+    command: fetch_gw_data(target_name, gw_crn_sites, viz_start_date, viz_end_date, gw_param_cd, stat_cd = I("00001"), 200)

--- a/1_fetch.yml
+++ b/1_fetch.yml
@@ -6,6 +6,7 @@ packages:
   - sf
 
 sources:
+  - 1_fetch/src/fetch_s3.R
   - 1_fetch/src/fetch_nwis.R
   - 1_fetch/src/fetch_gwcrn.R
 
@@ -16,7 +17,16 @@ targets:
       - 1_fetch/out/gw_data.rds
       - 1_fetch/out/gw_crn_data.rds
 
-##-- All GW sites with continuous data --##
+##-- Historic GW sites and data --##
+
+  1_fetch/out/historic_gw_site_info.rds:
+    command: fetch_s3(target_name, historic_site_info_s3_fn)
+  1_fetch/out/historic_gw_data.csv:
+    command: fetch_s3(target_name, historic_data_s3_fn)
+  # 1_fetch/out/historic_gw_quantiles.csv:
+  #   command: fetch_s3(target_name, historic_quantiles_s3_fn)
+
+##-- GW sites and data for current viz time period --##
   
   gw_sites:
     command: fetch_gw_sites(start_date, end_date, gw_param_cd)

--- a/1_fetch/src/fetch_s3.R
+++ b/1_fetch/src/fetch_s3.R
@@ -1,0 +1,11 @@
+# s3_get will only download and save the file exactly in the filepath it appears on S3
+# So, this function uses S3_get but then moves the file where we want it
+fetch_s3 <- function(target_name, s3_file) {
+  local_file <- s3_get(s3_file) 
+  file.copy(local_file, target_name, overwrite = TRUE)
+  file.remove(local_file)
+  
+  # Clean up and remove the dir if there are no files
+  if(length(list.files("gw-conditions")) == 0) unlink(dirname(local_file), recursive = TRUE)
+  
+}

--- a/3_visualize.yml
+++ b/3_visualize.yml
@@ -17,6 +17,6 @@ targets:
   3_visualize/out/daily_timestep_frames.yml:
     command: do_daily_timestep_tasks(
       target_name, 
-      start_date, 
-      end_date,
+      viz_start_date, 
+      viz_end_date,
       '3_visualize/src/visualize_cartogram.R')

--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ Similar to gage-conditions-gif but for groundwater!
 
 THE ANALYSIS IN THIS VIZ REPO (AS IT CURRENTLY STANDS 12/23/2020) IS NOT MEANT TO BE FINAL. JUST USED AS AN EXAMPLE OF HOW TO BUILD A VIDEO-BASED DATAVIZ USING SCIPIPER
 
+### Build the historic data
+
+The historic data pipeline (`0_historic.yml`) is decoupled from the rest of the pipeline. It will build only when you run `scmake(remake_file = "0_historic.yml")`. Otherwise, the `1_fetch.yml` part of the pipeline will assume the historic data is on S3 ready to use and will download the data using the filepaths described in `0_config.yml`.
+
 ### How to build the viz:
 
 To build, check the `start_date` and `end_date` in `0_config.yml`. Then, run the following and look in your `4_animate/out` folder for the video.

--- a/lib/cfg/s3_config.yml
+++ b/lib/cfg/s3_config.yml
@@ -1,0 +1,3 @@
+profile: 'default'
+
+bucket: 'vizlab-data'

--- a/remake.yml
+++ b/remake.yml
@@ -10,8 +10,16 @@ include:
 targets:
   build_viz:
     depends: 
-      - 0_config
       - 1_fetch
       - 2_process
       - 3_visualize
       - 4_animate
+
+# The historic data used in 1_fetch has been prebuilt by the 0_historic pipeline.
+# 
+# The 1_fetch pipeline will download the needed historic data from S3 using the 
+#   filenames specified in 0_config. 
+# 
+# If you need to regenerate the historic data, you will need to build the 0_historic
+#   pipeline itself (which is decoupled from the rest of this pipeline). To do so,
+#   run, scmake(remake_file = "0_historic.yml")


### PR DESCRIPTION
Added as a largely disconnected pipeline, where AWS S3 is being used for storage. Only one person should need to build 0_historic by running `scmake(remake_file = "0_historic.yml")`. All others will build the targets that run the function `fetch_s3` to pull down the data.

@collnell let's talk about these changes today because they are fairly significant changes to the existing pipeline.