### PR TITLE
need rowwise when using approx

### DIFF
--- a/2_process/src/compare_to_historic.R
+++ b/2_process/src/compare_to_historic.R
@@ -23,10 +23,12 @@ compare_to_historic <- function(target_name, historic_quantile_fn, current_data_
       filter(site_no == site) %>% 
       # Figure out the corresponding quantile for each daily value
       # If there are no non-NA quantiles available, return NA
+      rowwise() %>% 
       mutate(daily_quant = ifelse(
         nrow(site_quantiles) > 0, 
         yes = approx(x = site_quantiles$quantile_va, y = site_quantiles$quantile_nm, xout = GWL)$y,
-        no = NA))
+        no = NA)) %>% 
+      ungroup()
     
     # TODO: Handle any new max or new min values when using dates outside of dates used to calculate historic vals
     


### PR DESCRIPTION
Without `rowwise`, every gage was getting the same quantile for every day. Discovered when I was digging into using the sites from John (see before/after below). Updated & generated a new histogram. This one makes more sense to me.

![image](https://user-images.githubusercontent.com/13220910/111230185-333ad300-85b5-11eb-96a7-555c9126ff92.png)

John sites before `rowwise` fix:

![image](https://user-images.githubusercontent.com/13220910/111230281-56fe1900-85b5-11eb-908e-2894374b773b.png)

John sites after `rowwise` fix:

![image](https://user-images.githubusercontent.com/13220910/111230312-6715f880-85b5-11eb-9d30-c7ba11964089.png)
