### PR TITLE
Pull missing historic data

### DIFF
--- a/0_config.yml
+++ b/0_config.yml
@@ -20,15 +20,17 @@ targets:
   # like redownloading the data, as the above trigger).
   historic_min_yrs_per_site_for_quantile_calc:
     command: I(3)
+  historic_site_types_for_quantile_calc:
+    command: c(I('GW'))
   
   # Building these are completely decoupled from the rest of the pipeline
   # Use these objects in 1_fetch to s3_get the data
-  historic_site_info_s3_fn:
-    command: c(I('gw-conditions/historic_gw_site_info.rds'))
-  historic_data_s3_fn:
-    command: c(I('gw-conditions/historic_gw_data.csv'))
+  historic_unfiltered_site_info_s3_fn:
+    command: c(I('gw-conditions/historic_gw_site_info_unfiltered.rds'))
+  historic_unfiltered_data_s3_fn:
+    command: c(I('gw-conditions/historic_gw_data_unfiltered.csv'))
   historic_filtered_data_s3_fn:
-    command: c(I('gw-conditions/filtered_historic_gw_data.csv'))
+    command: c(I('gw-conditions/historic_gw_data_filtered.csv'))
   historic_quantiles_s3_fn:
     command: c(I('gw-conditions/historic_gw_quantiles.csv'))
   

--- a/0_config.yml
+++ b/0_config.yml
@@ -15,6 +15,11 @@ targets:
     command: I(50)
   historic_uv_fetch_size_limit:
     command: I(10)
+    
+  # This one will initiate a rebuild of the quantiles (still lengthy, but not 
+  # like redownloading the data, as the above trigger).
+  historic_min_yrs_per_site_for_quantile_calc:
+    command: I(3)
   
   # Building these are completely decoupled from the rest of the pipeline
   # Use these objects in 1_fetch to s3_get the data
@@ -22,6 +27,8 @@ targets:
     command: c(I('gw-conditions/historic_gw_site_info.rds'))
   historic_data_s3_fn:
     command: c(I('gw-conditions/historic_gw_data.csv'))
+  historic_filtered_data_s3_fn:
+    command: c(I('gw-conditions/filtered_historic_gw_data.csv'))
   historic_quantiles_s3_fn:
     command: c(I('gw-conditions/historic_gw_quantiles.csv'))
   

--- a/0_config.yml
+++ b/0_config.yml
@@ -4,12 +4,17 @@ targets:
   
 ##-- Historic data configs --##
 
+  # Don't touch these unless you have a REALLY good reason because they
+  # will trigger rebuilds of the historic pipeline and the instantaneous
+  # part takes a VERY long time.
   historic_start_date:
-    command: as.Date(I('1800-01-01'))
+    command: as.Date(I('1900-01-01'))
   historic_end_date:
     command: as.Date(I('2020-12-31'))
-  historic_fetch_size_limit:
+  historic_dv_fetch_size_limit:
     command: I(50)
+  historic_uv_fetch_size_limit:
+    command: I(10)
   
   # Building these are completely decoupled from the rest of the pipeline
   # Use these objects in 1_fetch to s3_get the data

--- a/0_historic.yml
+++ b/0_historic.yml
@@ -18,6 +18,7 @@ targets:
     depends:
       - gw-conditions/historic_gw_site_info.rds.ind
       - gw-conditions/historic_gw_data.csv.ind
+      - gw-conditions/filtered_historic_gw_data.csv.ind
       - gw-conditions/historic_gw_quantiles.csv.ind
 
 ##-- All GW sites with continuous data for all time --##
@@ -55,11 +56,15 @@ targets:
       '0_historic/src/fetch_nwis_historic.R')
   0_historic/out/historic_gw_data.csv:
     command: combine_gw_data('0_historic/out/historic_gw_data_dv.csv', '0_historic/out/historic_gw_data_uv.csv')
+  
+##-- Use historic data, filter to sites that meet a min years requirement, and calculate quantiles --##
 
   quantiles_to_calc:
     command: seq(0, 1, by = 0.05)
+  0_historic/tmp/filtered_historic_gw_data.csv:
+    command: apply_min_years_filter(target_name, "0_historic/out/historic_gw_data.csv", historic_min_yrs_per_site_for_quantile_calc)
   0_historic/out/historic_gw_quantiles.csv:
-   command: calculate_historic_quantiles(target_name, "0_historic/out/historic_gw_data.csv", quantiles_to_calc)
+   command: calculate_historic_quantiles(target_name, "0_historic/tmp/filtered_historic_gw_data.csv", quantiles_to_calc)
   
 ##-- Now push historic data and quantiles to S3 to be used in the rest of the pipeline --##
 
@@ -68,6 +73,9 @@ targets:
   
   gw-conditions/historic_gw_data.csv.ind:
     command: s3_put(target_name, local_source = '0_historic/out/historic_gw_data.csv')
+  
+  gw-conditions/filtered_historic_gw_data.csv.ind:
+    command: s3_put(target_name, local_source = '0_historic/tmp/filtered_historic_gw_data.csv')
   
   gw-conditions/historic_gw_quantiles.csv.ind:
    command: s3_put(target_name, local_source = '0_historic/out/historic_gw_quantiles.csv')

--- a/0_historic.yml
+++ b/0_historic.yml
@@ -8,7 +8,7 @@ packages:
   - tidyverse
 
 sources:
-  - 0_historic/src/do_gw_fetch.R
+  - 0_historic/src/do_historic_gw_fetch.R
   - 0_historic/src/fetch_nwis_historic.R
   - 0_historic/src/calculate_historic_quantiles.R
 
@@ -22,23 +22,40 @@ targets:
 
 ##-- All GW sites with continuous data for all time --##
   
-  historic_gw_sites:
-    command: fetch_gw_historic_sites(historic_start_date, historic_end_date, gw_param_cd)
+  historic_gw_sites_all:
+    command: fetch_gw_historic_sites(historic_start_date, historic_end_date, viz_bounding_box, gw_param_cd)
+  historic_gw_sites_dv:
+    command: pull_sites_by_service(historic_gw_sites_all, I("dv"))
+  historic_gw_sites_uv:
+    command: pull_sites_by_service(historic_gw_sites_all, I("uv"))
   
   historic_gw_site_info:
-    command: fetch_gw_site_info(historic_gw_sites)
+    command: fetch_gw_site_info(historic_gw_sites_all)
   0_historic/out/historic_gw_site_info.rds:
     command: saveRDS(file = target_name, historic_gw_site_info)
   
-  0_historic/out/historic_gw_data.csv:
+  0_historic/out/historic_gw_data_dv.csv:
     command: do_historic_gw_fetch(
       final_target = target_name,
       task_makefile = I('0_historic_fetch_tasks.yml'),
-      gw_site_nums = historic_gw_sites,
-      request_limit = historic_fetch_size_limit,
-      '0_historic/src/do_gw_fetch.R',
+      gw_site_nums = historic_gw_sites_dv,
+      service_cd = I('dv'),
+      request_limit = historic_dv_fetch_size_limit,
+      '0_historic/src/do_historic_gw_fetch.R',
       '0_historic/src/fetch_nwis_historic.R')
-  
+  # Task table for `uv` includes a step to average the data to daily values.
+  0_historic/out/historic_gw_data_uv.csv:
+    command: do_historic_gw_fetch(
+      final_target = target_name,
+      task_makefile = I('0_historic_fetch_tasks.yml'),
+      gw_site_nums = historic_gw_sites_uv,
+      service_cd = I('uv'),
+      request_limit = historic_uv_fetch_size_limit,
+      '0_historic/src/do_historic_gw_fetch.R',
+      '0_historic/src/fetch_nwis_historic.R')
+  0_historic/out/historic_gw_data.csv:
+    command: combine_gw_data('0_historic/out/historic_gw_data_dv.csv', '0_historic/out/historic_gw_data_uv.csv')
+
   quantiles_to_calc:
     command: seq(0, 1, by = 0.05)
   0_historic/out/historic_gw_quantiles.csv:

--- a/0_historic.yml
+++ b/0_historic.yml
@@ -55,7 +55,7 @@ targets:
       '0_historic/src/do_historic_gw_fetch.R',
       '0_historic/src/fetch_nwis_historic.R')
   0_historic/out/historic_gw_data.csv:
-    command: combine_gw_data('0_historic/out/historic_gw_data_dv.csv', '0_historic/out/historic_gw_data_uv.csv')
+    command: combine_gw_uv_and_dv(target_name, '0_historic/out/historic_gw_data_dv.csv', '0_historic/out/historic_gw_data_uv.csv')
   
 ##-- Use historic data, filter to sites that meet a min years requirement, and calculate quantiles --##
 

--- a/0_historic.yml
+++ b/0_historic.yml
@@ -10,15 +10,16 @@ packages:
 sources:
   - 0_historic/src/do_historic_gw_fetch.R
   - 0_historic/src/fetch_nwis_historic.R
+  - 0_historic/src/filter_historic_fetched_data.R
   - 0_historic/src/calculate_historic_quantiles.R
 
 targets:
 
   0_historic:
     depends:
-      - gw-conditions/historic_gw_site_info.rds.ind
-      - gw-conditions/historic_gw_data.csv.ind
-      - gw-conditions/filtered_historic_gw_data.csv.ind
+      - gw-conditions/historic_gw_site_info_unfiltered.rds.ind
+      - gw-conditions/historic_gw_data_unfiltered.csv.ind
+      - gw-conditions/historic_gw_data_filtered.csv.ind
       - gw-conditions/historic_gw_quantiles.csv.ind
 
 ##-- All GW sites with continuous data for all time --##
@@ -59,23 +60,28 @@ targets:
   
 ##-- Use historic data, filter to sites that meet a min years requirement, and calculate quantiles --##
 
+  0_historic/out/filtered_historic_gw_data.csv:
+    command: filter_historic_fetched_data(
+      target_name, 
+      historic_gw_data_fn = "0_historic/out/historic_gw_data.csv", 
+      min_years = historic_min_yrs_per_site_for_quantile_calc,
+      allowed_site_types = historic_site_types_for_quantile_calc)
+  
   quantiles_to_calc:
     command: seq(0, 1, by = 0.05)
-  0_historic/tmp/filtered_historic_gw_data.csv:
-    command: apply_min_years_filter(target_name, "0_historic/out/historic_gw_data.csv", historic_min_yrs_per_site_for_quantile_calc)
   0_historic/out/historic_gw_quantiles.csv:
-   command: calculate_historic_quantiles(target_name, "0_historic/tmp/filtered_historic_gw_data.csv", quantiles_to_calc)
+   command: calculate_historic_quantiles(target_name, "0_historic/out/filtered_historic_gw_data.csv", quantiles_to_calc)
   
 ##-- Now push historic data and quantiles to S3 to be used in the rest of the pipeline --##
 
-  gw-conditions/historic_gw_site_info.rds.ind:
+  gw-conditions/historic_gw_site_info_unfiltered.rds.ind:
     command: s3_put(remote_ind = target_name, local_source = '0_historic/out/historic_gw_site_info.rds')
   
-  gw-conditions/historic_gw_data.csv.ind:
+  gw-conditions/historic_gw_data_unfiltered.csv.ind:
     command: s3_put(target_name, local_source = '0_historic/out/historic_gw_data.csv')
   
-  gw-conditions/filtered_historic_gw_data.csv.ind:
-    command: s3_put(target_name, local_source = '0_historic/tmp/filtered_historic_gw_data.csv')
+  gw-conditions/historic_gw_data_filtered.csv.ind:
+    command: s3_put(target_name, local_source = '0_historic/out/filtered_historic_gw_data.csv')
   
   gw-conditions/historic_gw_quantiles.csv.ind:
    command: s3_put(target_name, local_source = '0_historic/out/historic_gw_quantiles.csv')

--- a/0_historic/src/calculate_historic_quantiles.R
+++ b/0_historic/src/calculate_historic_quantiles.R
@@ -12,3 +12,20 @@ calculate_historic_quantiles <- function(target_name, historic_gw_data_fn, quant
     write_csv(target_name)
   
 }
+
+# Restrict the number of years
+apply_min_years_filter <- function(target_name, historic_gw_data_fn, min_years) {
+  
+  historic_gw_data <- read_csv(historic_gw_data_fn, col_types = 'cDn') 
+  
+  sites_meet_min_yrs <- historic_gw_data %>%  
+    group_by(site_no) %>% 
+    summarize(n_days = n()) %>% 
+    # Check that the number of days of data is at least 3 full years worth
+    filter(n_days >= 365*min_years) %>% 
+    pull(site_no)
+  
+  historic_gw_data %>% 
+    filter(site_no %in% sites_meet_min_yrs) %>% 
+    write_csv(target_name)
+}

--- a/0_historic/src/calculate_historic_quantiles.R
+++ b/0_historic/src/calculate_historic_quantiles.R
@@ -1,7 +1,7 @@
 # Per gage, calc quantiles using historic groundwater level data (no seasonality)
-calculate_historic_quantiles <- function(target_name, historic_gw_data, quantiles_to_calc) {
+calculate_historic_quantiles <- function(target_name, historic_gw_data_fn, quantiles_to_calc) {
   
-  read_csv("0_historic/out/historic_gw_data.csv", col_types = 'cDn') %>% 
+  read_csv(historic_gw_data_fn, col_types = 'cDn') %>% 
     split(.$site_no) %>% 
     map_dfr(., function(.x) {
       quants <- quantile(.x$GWL, quantiles_to_calc, na.rm = TRUE)

--- a/0_historic/src/calculate_historic_quantiles.R
+++ b/0_historic/src/calculate_historic_quantiles.R
@@ -17,20 +17,3 @@ calculate_historic_quantiles <- function(target_name, historic_gw_data_fn, quant
     write_csv(target_name)
   
 }
-
-# Restrict the number of years
-apply_min_years_filter <- function(target_name, historic_gw_data_fn, min_years) {
-  
-  historic_gw_data <- read_csv(historic_gw_data_fn, col_types = 'cDn') 
-  
-  sites_meet_min_yrs <- historic_gw_data %>%  
-    group_by(site_no) %>% 
-    summarize(n_days = n()) %>% 
-    # Check that the number of days of data is at least 3 full years worth
-    filter(n_days >= 365*min_years) %>% 
-    pull(site_no)
-  
-  historic_gw_data %>% 
-    filter(site_no %in% sites_meet_min_yrs) %>% 
-    write_csv(target_name)
-}

--- a/0_historic/src/calculate_historic_quantiles.R
+++ b/0_historic/src/calculate_historic_quantiles.R
@@ -1,3 +1,8 @@
+combine_gw_uv_and_dv <- function(out_file, dv_fn, uv_fn) {
+  bind_rows(read_csv(dv_fn), read_csv(uv_fn)) %>% 
+    write_csv(out_file)
+}
+
 # Per gage, calc quantiles using historic groundwater level data (no seasonality)
 calculate_historic_quantiles <- function(target_name, historic_gw_data_fn, quantiles_to_calc) {
   

--- a/0_historic/src/fetch_nwis_historic.R
+++ b/0_historic/src/fetch_nwis_historic.R
@@ -3,38 +3,89 @@ fetch_gw_historic_sites <- function(start_date, end_date, bounding_box, param_cd
   
   hucs <- zeroPad(1:21, 2) # all hucs
   
-  sites <- c()
+  sites <- tibble()
   for(huc in hucs){
     message(sprintf("Trying HUC %s ...", huc))
     sites <- tryCatch(
       whatNWISdata(huc = huc, 
-                   service = "dv", 
                    startDate = start_date,
                    endDate = end_date,
-                   parameterCd = param_cd,
-                   statCd = "00003") %>%
-        pull(site_no) %>%
+                   parameterCd = param_cd) %>% 
+        apply_selection_criteria() %>% 
         unique(), 
       error = function(e) return()
-    ) %>% c(sites)
+    ) %>% bind_rows(sites)
   }
-  
+    
   return(sites)
 }
 
-fetch_gw_site_info <- function(sites) {
-  readNWISsite(sites) %>% 
+apply_selection_criteria <- function(df) {
+  # Choose either dv or uv to pull
+  # Keep oldest record either UV or DV+00003, then choose DV if tie
+  df %>% 
+    filter(data_type_cd %in% c("uv", "dv"),
+           is.na(stat_cd) | stat_cd == "00003") %>% 
+    group_by(site_no) %>% 
+    # Account for the fact that inst data will have reported data for today's data but "daily" data will not 
+    # yet since the day has to complete first, so having one day of data more than dv shouldn't cause us to 
+    # choose instantaneous instead. The same is true if there were partial days on the front end (I noticed
+    # quite a few instances where "uv" started one day before "dv" and I imagine this is because the day was
+    # only partially recorded, so they didn't want to include a daily value. This appears to happen more
+    # often then them starting on the same day, so I may miss a few that don't do this but willing to take
+    # the risk.)
+    mutate(begin_date_fix = ifelse(data_type_cd == "uv", 1, 0), # can't return dates from ifelse
+           begin_date = begin_date + begin_date_fix,
+           end_date_fix = ifelse(data_type_cd == "uv", 1, 0), # can't return dates from ifelse
+           end_date = end_date - end_date_fix) %>%
+    # Handle ties, by sorting so "dv" is first because `which.max` will return the first one if there is a tie
+    arrange(site_no, data_type_cd) %>% # "dv" comes before "uv" alphabetically
+    mutate(to_keep = which.max(end_date - begin_date),
+           keep_row = row_number() == to_keep) %>% 
+    ungroup() %>% 
+    filter(keep_row) %>% 
+    select(site_no, data_type_cd)
+}
+
+pull_sites_by_service <- function(site_df, service) {
+  site_df %>% filter(data_type_cd == service) %>% pull(site_no)
+}
+
+fetch_gw_site_info <- function(site_df) {
+  readNWISsite(site_df$site_no) %>% 
     select(site_no, station_nm, state_cd, dec_lat_va, dec_long_va)
 }
 
-fetch_gw_historic <- function(target_name, gw_sites, start_date, end_date, param_cd, stat_cd) {
+fetch_gw_historic_dv <- function(target_name, gw_sites, start_date, end_date, param_cd) {
   readNWISdv(
     siteNumbers = gw_sites,
     startDate = start_date,
     endDate = end_date,
     parameterCd = param_cd,
-    statCd = stat_cd) %>%
-    rename(GWL := sprintf("X_%s_%s", param_cd, stat_cd)) %>% 
+    statCd = "00003") %>%
+    rename(GWL := sprintf("X_%s_00003", param_cd)) %>% 
     select(site_no, Date, GWL) %>% 
     write_feather(target_name)
+}
+
+fetch_gw_historic_uv <- function(target_name, gw_sites, start_date, end_date, param_cd) {
+  readNWISuv(
+    siteNumbers = gw_sites,
+    startDate = start_date,
+    endDate = end_date,
+    parameterCd = param_cd) %>%
+    rename(GWL_inst := sprintf("X_%s_00000", param_cd)) %>% 
+    write_feather(target_name)
+}
+
+convert_uv_to_dv <- function(target_name, gw_uv_data_fn) {
+  read_feather(gw_uv_data_fn) %>% 
+    mutate(Date = as.Date(dateTime)) %>% 
+    group_by(site_no, Date) %>% 
+    summarize(GWL = mean(GWL_inst, na.rm = TRUE)) %>% 
+    write_feather(target_name)
+}
+
+combine_gw_data <- function(dv_fn, uv_fn) {
+  bind_rows(read_csv(dv_fn, col_types = 'cDn'), read_csv(uv_fn, col_types = 'cDn'))
 }

--- a/0_historic/src/filter_historic_fetched_data.R
+++ b/0_historic/src/filter_historic_fetched_data.R
@@ -1,0 +1,27 @@
+filter_historic_fetched_data <- function(target_name, historic_gw_data_fn, min_years, allowed_site_types) {
+  
+  historic_gw_data <- read_csv(historic_gw_data_fn, col_types = 'cDn') 
+  
+  sites_meet_min_yrs <- historic_gw_data %>%  
+    group_by(site_no) %>% 
+    summarize(n_days = n()) %>% 
+    # Check that the number of days of data is at least 3 full years worth
+    filter(n_days >= 365*min_years) %>% 
+    pull(site_no)
+  
+  # 6/4/2021: One of the sites had its leading zero dropped along the way. I  
+  # know that it is a LK site, which we are not keeping, so going to manually 
+  # filter it out for now and return to this the next time we go to rebuild.
+  site_nums <- unique(historic_gw_data$site_no)
+  i_bad <- which(site_nums %in% c("5346050")) # It should be "05346050"
+  sites_meet_site_tp <- readNWISsite(site_nums[-i_bad]) %>% 
+    select(site_no, site_tp_cd) %>% 
+    filter(site_tp_cd %in% allowed_site_types) %>% 
+    pull(site_no)
+  
+  # Actually restrict the data based on these criteria
+  historic_gw_data %>% 
+    filter(site_no %in% sites_meet_min_yrs) %>% 
+    filter(site_no %in% sites_meet_site_tp) %>%
+    write_csv(target_name) 
+}

--- a/1_fetch.yml
+++ b/1_fetch.yml
@@ -20,10 +20,15 @@ targets:
 
 ##-- Historic GW sites and data --##
 
+  # All sites (including those with years < min_years)
   1_fetch/out/historic_gw_site_info.rds:
     command: fetch_s3(target_name, historic_site_info_s3_fn)
+  # All data (including those with years < min_years)
   1_fetch/out/historic_gw_data.csv:
     command: fetch_s3(target_name, historic_data_s3_fn)
+  # This data and the quantiles are just for sites with > min_years
+  1_fetch/out/filtered_historic_gw_data.csv:
+    command: fetch_s3(target_name, historic_filtered_data_s3_fn)
   1_fetch/out/historic_gw_quantiles.csv:
     command: fetch_s3(target_name, historic_quantiles_s3_fn)
 

--- a/1_fetch.yml
+++ b/1_fetch.yml
@@ -21,14 +21,18 @@ targets:
 ##-- Historic GW sites and data --##
 
   # All sites (including those with years < min_years)
-  1_fetch/out/historic_gw_site_info.rds:
-    command: fetch_s3(target_name, historic_site_info_s3_fn)
+  1_fetch/out/historic_gw_site_info_unfiltered.rds:
+    command: fetch_s3(target_name, historic_unfiltered_site_info_s3_fn)
   # All data (including those with years < min_years)
-  1_fetch/out/historic_gw_data.csv:
-    command: fetch_s3(target_name, historic_data_s3_fn)
+  1_fetch/out/historic_gw_data_unfiltered.csv:
+    command: fetch_s3(target_name, historic_unfiltered_data_s3_fn)
   # This data and the quantiles are just for sites with > min_years
-  1_fetch/out/filtered_historic_gw_data.csv:
+  1_fetch/out/historic_gw_data_filtered.csv:
     command: fetch_s3(target_name, historic_filtered_data_s3_fn)
+  
+  # Only this one is absolutely necessary to run the pipeline in its current 
+  # state (2_process/out/gw_daily_quantiles.csv depends on it). The others
+  # will not build unless you manually build the targets.
   1_fetch/out/historic_gw_quantiles.csv:
     command: fetch_s3(target_name, historic_quantiles_s3_fn)
 


### PR DESCRIPTION
We are missing some critical data. Read more about what we are missing in #9. 

This PR does the following (for `0_historic.yml`!):

1. Find all GW sites with data for `pcode = 72019` in either the UV or DV service.
2. When DV mean is not available, pull UV instead and average to a DV. 
3. Don't bother for sites that don't have at least 3 years of data (#11)
4. As of https://github.com/USGS-VIZLAB/gw-conditions/pull/20/commits/09967ccfa3b68d5caf0e49c7076873fc9986e5a5, this PR also fixes #10 where we are only keeping `site_tp_cd == "GW"`

--- EDIT: the problem described below is fixed! _**Still need to figure out KS and FL, but that will happen in a different PR**_

This is MOSTLY working. I.e. we are successfully pulling and averaging UVs into DVs BUT I think there is something wrong in this logic still. I _**think**_ something is off with the combine step and the data is being pulled just fine. How do I know? Keep reading ...

# Did these changes fix things? Almost!
```r
library(scipiper)
library(tidyverse)
library(sf)

proj_str <- scmake("proj_str")
usa_sf <- st_as_sf(maps::map('usa', fill = TRUE, plot = FALSE)) %>% st_transform(proj_str)
state_sf <- st_as_sf(maps::map('state', fill = TRUE, plot = FALSE)) %>% st_transform(proj_str)
site_info <- readRDS("0_historic/out/historic_gw_site_info.rds")
```

Let's look at the resulting data from pulling DV means & also UV but summarizing into DV means. This can be done by inspecting what sites are still included after pulling and saving all the UV and DV data into two CSVs. Then, I put them both on a plot where sites that used the DV service are salmon colored and sites that summarized data from the UV service into daily means are blue.

```r
# UV ALONE
pulled_uv_data <- read_csv("0_historic/out/historic_gw_data_uv.csv")
sites_to_map_uv <- site_info %>% filter(site_no %in% unique(pulled_uv_data$site_no))

# DV ALONE
pulled_dv_data <- read_csv("0_historic/out/historic_gw_data_dv.csv")
sites_to_map_dv <- site_info %>% filter(site_no %in% unique(pulled_dv_data$site_no))

ggplot(usa_sf) + 
  geom_sf(color = NA) + 
  geom_sf(data = state_sf, color = "white") +
  geom_sf(data = st_transform(st_as_sf(sites_to_map_dv, coords = c("dec_long_va", "dec_lat_va"), crs = "+proj=longlat +datum=WGS84"), proj_str), color = "salmon") +
  geom_sf(data = st_transform(st_as_sf(sites_to_map_uv, coords = c("dec_long_va", "dec_lat_va"), crs = "+proj=longlat +datum=WGS84"), proj_str), color = "blue") +
  coord_sf() + 
  theme_void()
```
![image](https://user-images.githubusercontent.com/13220910/120835312-c5ee6c80-c529-11eb-9854-59dec92b7782.png)

Now, let's look at what sites we have after these two datasets have been combined into one massive daily groundwater CSV. This is where I see holes in the data and they appear to be exactly the sites that used UV to derive daily values.
```
# Now the combined data
combined_data <- read_csv("0_historic/out/historic_gw_data.csv")
sites_to_map_combined <- site_info %>% filter(site_no %in% unique(combined_data$site_no))

ggplot(usa_sf) + 
  geom_sf(color = NA) + 
  geom_sf(data = state_sf, color = "white") +
  geom_sf(data = st_transform(st_as_sf(sites_to_map_combined, coords = c("dec_long_va", "dec_lat_va"), crs = "+proj=longlat +datum=WGS84"), proj_str)) +
  coord_sf() + 
  theme_void()
```

![image](https://user-images.githubusercontent.com/13220910/120835477-fcc48280-c529-11eb-9060-1fa89d4d9814.png)

Now to figure out why that combine isn't working ...
