### PR TITLE
Expand beyond conus for historic pull

### DIFF
--- a/0_config.yml
+++ b/0_config.yml
@@ -60,11 +60,12 @@ targets:
   gw_param_cd:
     command: c(I('72019'))
   
-  # Additional fetch params for the states that don't report 72019 pcode
-  addl_gw_param_cd:
-    command: c(I('62610'))
+  # Additional fetch configs for the states that don't report 72019 pcode
+  # The values of the pcodes should match up with their corresponding states
+  addl_gw_param_cds:
+    command: c(I('62610'), I('62610'), I('72150'))
   addl_states:
-    command: c(I('FL'), I('KS'))
+    command: c(I('FL'), I('KS'), I('HI'))
 
 ##-- Process configs --##
 

--- a/0_config.yml
+++ b/0_config.yml
@@ -45,7 +45,7 @@ targets:
   viz_start_date:
     command: as.Date(I('2020-10-01'))
   viz_end_date:
-    command: as.Date(I('2020-09-30'))
+    command: as.Date(I('2021-09-30'))
   # Use bounding box in case we want to do this regionally someday
   # Start with CONUS only
   # I don't think this is being used any more ...

--- a/0_config.yml
+++ b/0_config.yml
@@ -16,6 +16,10 @@ targets:
   historic_uv_fetch_size_limit:
     command: I(10)
   
+  # Use all states and U.S. territories for historic data fetch
+  historic_fetch_bounding_box:
+   command: fetch_usa_bbox()
+  
   # This one will initiate a rebuild of the quantiles (still lengthy, but not 
   # like redownloading the data, as the above trigger).
   historic_min_yrs_per_site_for_quantile_calc:

--- a/0_config.yml
+++ b/0_config.yml
@@ -15,7 +15,7 @@ targets:
     command: I(50)
   historic_uv_fetch_size_limit:
     command: I(10)
-    
+  
   # This one will initiate a rebuild of the quantiles (still lengthy, but not 
   # like redownloading the data, as the above trigger).
   historic_min_yrs_per_site_for_quantile_calc:
@@ -42,12 +42,10 @@ targets:
     command: as.Date(I('2019-10-01'))
   viz_end_date:
     command: as.Date(I('2020-09-30'))
-  # This was a useful resource: https://anthonylouisdagostino.com/bounding-boxes-for-all-us-states/
   # Use bounding box in case we want to do this regionally someday
-  # Must be west longitude, south latitude, east longitude, and then north latitude
   # Start with CONUS only
   viz_bounding_box:
-   command: c(I(-124.409591), I(24.523096), I(-66.949895), I(49.384358))
+   command: fetch_usa_bbox(conus_only = TRUE)
   dv_fetch_size_limit:
     command: I(200)
   uv_fetch_size_limit:

--- a/0_config.yml
+++ b/0_config.yml
@@ -43,11 +43,12 @@ targets:
 ##-- Fetch configs --##
   
   viz_start_date:
-    command: as.Date(I('2019-10-01'))
+    command: as.Date(I('2020-10-01'))
   viz_end_date:
     command: as.Date(I('2020-09-30'))
   # Use bounding box in case we want to do this regionally someday
   # Start with CONUS only
+  # I don't think this is being used any more ...
   viz_bounding_box:
    command: fetch_usa_bbox(conus_only = TRUE)
   dv_fetch_size_limit:

--- a/0_historic.yml
+++ b/0_historic.yml
@@ -12,6 +12,7 @@ sources:
   - 0_historic/src/fetch_nwis_historic.R
   - 0_historic/src/filter_historic_fetched_data.R
   - 0_historic/src/calculate_historic_quantiles.R
+  - 0_historic/src/do_historic_addl_param_fetch.R
 
 targets:
 
@@ -38,7 +39,7 @@ targets:
       task_makefile = I('0_historic_fetch_tasks.yml'),
       gw_site_nums = historic_gw_sites_dv,
       gw_site_nums_obj_nm = I('historic_gw_sites_dv'),
-      param_cd_obj_nm = I('gw_param_cd'),
+      param_cd = gw_param_cd,
       service_cd = I('dv'),
       request_limit = historic_dv_fetch_size_limit,
       '0_historic/src/do_historic_gw_fetch.R',
@@ -50,27 +51,23 @@ targets:
       task_makefile = I('0_historic_fetch_tasks.yml'),
       gw_site_nums = historic_gw_sites_uv,
       gw_site_nums_obj_nm = I('historic_gw_sites_uv'),
-      param_cd_obj_nm = I('gw_param_cd'),
+      param_cd = gw_param_cd,
       service_cd = I('uv'),
       request_limit = historic_uv_fetch_size_limit,
       '0_historic/src/do_historic_gw_fetch.R',
       '0_historic/src/fetch_nwis_historic.R')
   
-  # Special pull for just KS & just FL using `62610`.
+  # Special pull for just KS & just FL using `62610`. Plus, HI using `72150`.
   # Read all about why on GitHub: https://github.com/USGS-VIZLAB/gw-conditions/issues/9
-  addl_site_nums:
-    command: fetch_addl_uv_sites(addl_states, addl_gw_param_cd, historic_start_date, historic_end_date)
   0_historic/out/historic_gw_data_uv_addl.csv:
-    command: do_historic_gw_fetch(
-      final_target = target_name,
-      task_makefile = I('0_historic_fetch_tasks.yml'),
-      gw_site_nums = addl_site_nums,
-      gw_site_nums_obj_nm = I('addl_site_nums'),
-      param_cd_obj_nm = I('addl_gw_param_cd'),
-      service_cd = I('uv'),
-      request_limit = historic_uv_fetch_size_limit,
-      '0_historic/src/do_historic_gw_fetch.R',
-      '0_historic/src/fetch_nwis_historic.R')
+    command: do_historic_addl_param_fetch(
+      target_name,
+      addl_states, 
+      addl_gw_param_cds, 
+      historic_start_date, 
+      historic_end_date)
+  addl_site_nums:
+    command: pull_site_nums('0_historic/out/historic_gw_data_uv_addl.csv')
   
   0_historic/out/historic_gw_data.csv:
     command: combine_gw_fetches(
@@ -80,7 +77,7 @@ targets:
       '0_historic/out/historic_gw_data_uv_addl.csv')
   
   historic_gw_sites:
-    command: combine_gw_sites(historic_gw_sites_all, addl_site_nums, gw_param_cd, addl_gw_param_cd)
+    command: combine_gw_sites(historic_gw_sites_all, addl_site_nums, gw_param_cd, addl_gw_param_cds)
   historic_gw_site_info:
     command: fetch_gw_site_info('0_historic/out/historic_gw_data.csv')
   0_historic/out/historic_gw_site_info.rds:

--- a/0_historic.yml
+++ b/0_historic.yml
@@ -77,7 +77,7 @@ targets:
       '0_historic/out/historic_gw_data_uv_addl.csv')
   
   historic_gw_sites:
-    command: combine_gw_sites(historic_gw_sites_all, addl_site_nums, gw_param_cd, addl_gw_param_cds)
+    command: combine_gw_sites(historic_gw_sites_all, addl_site_nums, gw_param_cd, addl_gw_param_cds, addl_states)
   historic_gw_site_info:
     command: fetch_gw_site_info('0_historic/out/historic_gw_data.csv')
   0_historic/out/historic_gw_site_info.rds:

--- a/0_historic.yml
+++ b/0_historic.yml
@@ -26,7 +26,7 @@ targets:
 ##-- All GW sites with continuous data for all time --##
   
   historic_gw_sites_all:
-    command: fetch_gw_historic_sites(historic_start_date, historic_end_date, viz_bounding_box, gw_param_cd)
+    command: fetch_gw_historic_sites(historic_start_date, historic_end_date, historic_fetch_bounding_box, gw_param_cd)
   historic_gw_sites_dv:
     command: pull_sites_by_service(historic_gw_sites_all, I("dv"))
   historic_gw_sites_uv:

--- a/0_historic/src/do_historic_addl_param_fetch.R
+++ b/0_historic/src/do_historic_addl_param_fetch.R
@@ -1,0 +1,105 @@
+do_historic_addl_param_fetch <- function(final_target, addl_states, addl_gw_param_cds, 
+                                         historic_start_date, historic_end_date) {
+  # Special pull for just KS & just FL using `62610`. Plus, HI using `72150`.
+  # Read all about why on GitHub: https://github.com/USGS-VIZLAB/gw-conditions/issues/9
+  
+  # Creates this task makefile which then calls `do_historic_gw_fetch()`
+  # and makes additional task makefiles for each pcode.
+  task_makefile <- '0_historic_addl_fetch_tasktable.yml'
+  
+  fetch_cfg <- tibble(
+    param_cd = addl_gw_param_cds,
+    state_cd = addl_states
+  ) 
+  tasks <- unique(fetch_cfg$param_cd)
+  
+  identify_states <- create_task_step(
+    step_name = 'identify_states',
+    target_name = function(task_name, ...) {
+      sprintf('addl_states_%s', task_name)
+    },
+    command = function(task_name, ...) {
+      states <- filter(fetch_cfg, param_cd == task_name) %>% pull(state_cd)
+      sprintf("c(%s)", paste(sprintf("I('%s')", states), collapse = ", "))
+    }
+  )
+  
+  inventory_sites <- create_task_step(
+    step_name = 'inventory_sites',
+    target_name = function(task_name, ...) {
+      sprintf('addl_site_nums_%s', task_name)
+    },
+    command = function(..., task_name, steps) {
+      sprintf("fetch_addl_uv_sites(%s, I('%s'), historic_start_date, historic_end_date)", 
+              steps[["identify_states"]]$target_name, task_name)
+    }
+  )
+  
+  download_addl_data <- create_task_step(
+    step_name = 'download_addl_data',
+    target_name = function(task_name, ...) {
+      sprintf('0_historic/tmp/historic_gw_data_uv_addl_%s.csv', task_name)
+    },
+    command = function(..., task_name, steps) {
+      psprintf("do_historic_gw_fetch(",
+               "final_target = target_name,",
+               "task_makefile = I('0_historic_fetch_tasks.yml'),",
+               "gw_site_nums = %s," = steps[['inventory_sites']]$target_name,
+               "gw_site_nums_obj_nm = I('%s')," = steps[['inventory_sites']]$target_name,
+               "param_cd = I('%s')," = task_name,
+               "service_cd = I('uv'),",
+               "request_limit = historic_uv_fetch_size_limit,",
+               "'0_historic/src/do_historic_gw_fetch.R',",
+               "'0_historic/src/fetch_nwis_historic.R',",
+               "include_ymls = I('%s'))" = task_makefile)
+    }
+  )
+  
+  # Create the task plan
+  task_plan <- create_task_plan(
+    task_names = tasks,
+    task_steps = list(identify_states, inventory_sites, download_addl_data),
+    final_steps = "download_addl_data",
+    add_complete = FALSE)
+  
+  # Create the task remakefile
+  create_task_makefile(
+    task_plan = task_plan,
+    makefile = task_makefile,
+    include = c('0_historic.yml'),
+    sources = c('0_historic/src/do_historic_addl_param_fetch.R'),
+    packages = c('tidyverse', 'dataRetrieval', 'scipiper', 'purrr'),
+    final_targets = final_target,
+    finalize_funs = 'combine_addl_gw_files',
+    as_promises = TRUE,
+    tickquote_combinee_objects = TRUE)
+  
+  # Build the tasks
+  loop_tasks(task_plan = task_plan,
+             task_makefile = task_makefile,
+             num_tries = 3, # Try a few times, there could be some internet flakiness
+             n_cores = 1) # Only one core! Don't want to overwhelm NWIS services
+  
+  # Clean up files created
+  
+  # Remove the temporary target from remake's DB; it won't necessarily be a unique  
+  #   name and we don't need it to persist, especially since killing the task yaml
+  scdel(sprintf("%s_promise", basename(final_target)), remake_file=task_makefile)
+  # Delete task makefile since it is only needed internally for this function and  
+  #   not needed at all once loop_tasks is complete. Also delete temporary files
+  #   saved in order to decouple task makefile from `remake.yml`.
+  file.remove(task_makefile)
+  
+}
+
+combine_addl_gw_files <- function(target_name, ...) {
+  purrr::map(list(...), function(fn) read_csv(fn)) %>% 
+    bind_rows() %>% 
+    readr::write_csv(target_name)
+}
+
+pull_site_nums <- function(file_in) {
+  read_csv(file_in) %>%
+    pull(site_no) %>% 
+    unique()
+}

--- a/0_historic/src/do_historic_gw_fetch.R
+++ b/0_historic/src/do_historic_gw_fetch.R
@@ -1,4 +1,4 @@
-do_historic_gw_fetch <- function(final_target, task_makefile, gw_site_nums, gw_site_nums_obj_nm, param_cd_obj_nm, service_cd, request_limit, ...) {
+do_historic_gw_fetch <- function(final_target, task_makefile, gw_site_nums, gw_site_nums_obj_nm, param_cd, service_cd, request_limit, ..., include_ymls = NULL) {
   
   # Number indicating how many sites to include per dataRetrieval request to prevent
   # errors from requesting too much at once. More relevant for surface water requests.
@@ -49,7 +49,7 @@ do_historic_gw_fetch <- function(final_target, task_makefile, gw_site_nums, gw_s
                "gw_sites = %s," = steps[["subset_sites"]]$target_name,
                "start_date = historic_start_date,",
                "end_date = historic_end_date,",
-               "param_cd = %s)" = param_cd_obj_nm)
+               "param_cd = I('%s'))" = param_cd)
     }
   )
   
@@ -77,10 +77,11 @@ do_historic_gw_fetch <- function(final_target, task_makefile, gw_site_nums, gw_s
     add_complete = FALSE)
   
   # Create the task remakefile
+  if(is.null(include_ymls)) include_ymls <- '0_historic.yml' # include_ymls is NULL by default
   create_task_makefile(
     task_plan = task_plan,
     makefile = task_makefile,
-    include = c('0_historic.yml'),
+    include = include_ymls, 
     sources = c(...),
     packages = c('tidyverse', 'dataRetrieval', 'scipiper', 'feather', 'purrr'),
     final_targets = final_target,

--- a/0_historic/src/fetch_nwis_historic.R
+++ b/0_historic/src/fetch_nwis_historic.R
@@ -97,7 +97,7 @@ convert_uv_to_dv <- function(target_name, gw_uv_data_fn) {
   read_feather(gw_uv_data_fn) %>% 
     mutate(Date = as.Date(dateTime)) %>% 
     group_by(site_no, Date) %>% 
-    summarize(GWL = mean(GWL_inst, na.rm = TRUE)) %>% 
+    summarize(GWL = mean(GWL_inst, na.rm = TRUE), .groups = "keep") %>% 
     write_feather(target_name)
 }
 

--- a/0_historic/src/fetch_nwis_historic.R
+++ b/0_historic/src/fetch_nwis_historic.R
@@ -108,9 +108,16 @@ combine_gw_fetches <- function(target_name, dv_fn, uv_fn, uv_addl_fn) {
     write_csv(target_name)
 }
 
-combine_gw_sites <- function(gw_site_df, uv_addl_sites, param_cd, addl_param_cd) {
+combine_gw_sites <- function(gw_site_df, uv_addl_sites, param_cd, addl_param_cd, addl_states) {
+  # First find out what state the additional sites are in
+  # Then you can figure out what parameter code they should have
+  addl_sites_df <- readNWISsite(uv_addl_sites) %>%
+    mutate(state_abbr = stateCdLookup(state_cd)) %>% 
+    left_join(tibble(state_abbr = addl_states, 
+                     param_cd = addl_param_cd)) %>% 
+    mutate(data_type_cd = "uv") %>% 
+    select(site_no, data_type_cd, param_cd)
+  
   mutate(gw_site_df, param_cd = param_cd) %>% 
-    bind_rows(tibble(site_no = uv_addl_sites, 
-                     data_type_cd = "uv", 
-                     param_cd = addl_param_cd))
+    bind_rows(addl_sites_df)
 }

--- a/1_fetch.yml
+++ b/1_fetch.yml
@@ -9,6 +9,7 @@ sources:
   - 1_fetch/src/fetch_s3.R
   - 1_fetch/src/fetch_nwis.R
   - 1_fetch/src/do_gw_fetch.R
+  - 1_fetch/src/do_addl_gw_fetch.R
 
 targets:
 
@@ -48,19 +49,24 @@ targets:
   gw_sites_uv:
     command: pull_sites_by_query(gw_quantile_site_info, I("uv"), gw_param_cd)
   gw_sites_uv_addl:
-    command: pull_sites_by_query(gw_quantile_site_info, I("uv"), addl_gw_param_cd)
+    command: pull_sites_by_query(gw_quantile_site_info, I("uv"), addl_gw_param_cds)
   
+  # Task table for `dv` pulls
   1_fetch/out/gw_data_dv.csv:
     command: do_gw_fetch(
       final_target = target_name,
       task_makefile = I('1_fetch_tasks.yml'),
       gw_site_nums = gw_sites_dv,
       gw_site_nums_obj_nm = I('gw_sites_dv'),
-      param_cd_obj_nm = I('gw_param_cd'),
+      param_cd = gw_param_cd,
       service_cd = I('dv'),
       request_limit = dv_fetch_size_limit,
       '1_fetch/src/do_gw_fetch.R',
       '1_fetch/src/fetch_nwis.R')
+    depends:
+      - viz_start_date
+      - viz_end_date
+  
   # Task table for `uv` includes a step to average the data to daily values.
   1_fetch/out/gw_data_uv.csv:
     command: do_gw_fetch(
@@ -68,25 +74,24 @@ targets:
       task_makefile = I('1_fetch_tasks.yml'),
       gw_site_nums = gw_sites_uv,
       gw_site_nums_obj_nm = I('gw_sites_uv'),
-      param_cd_obj_nm = I('gw_param_cd'),
+      param_cd = gw_param_cd,
       service_cd = I('uv'),
       request_limit = uv_fetch_size_limit,
       '1_fetch/src/do_gw_fetch.R',
       '1_fetch/src/fetch_nwis.R')
+    depends:
+      - viz_start_date
+      - viz_end_date
       
-  # Special pull for just KS & just FL using `62610`.
+  # Special pull for just KS & just FL using `62610`. Plus, HI using `72150`.
   # Read all about why on GitHub: https://github.com/USGS-VIZLAB/gw-conditions/issues/9
   1_fetch/out/gw_data_uv_addl.csv:
-    command: do_gw_fetch(
+    command: do_addl_gw_fetch(
       final_target = target_name,
-      task_makefile = I('1_fetch_tasks.yml'),
-      gw_site_nums = gw_sites_uv_addl,
-      gw_site_nums_obj_nm = I('gw_sites_uv_addl'),
-      param_cd_obj_nm = I('addl_gw_param_cd'),
-      service_cd = I('uv'),
-      request_limit = uv_fetch_size_limit,
-      '1_fetch/src/do_gw_fetch.R',
-      '1_fetch/src/fetch_nwis.R')
+      addl_param_cds = addl_gw_param_cds)
+    depends:
+      - viz_start_date
+      - viz_end_date
 
   # Combine all data
   1_fetch/out/gw_data.csv:

--- a/1_fetch.yml
+++ b/1_fetch.yml
@@ -21,22 +21,25 @@ targets:
 
 ##-- Historic GW sites and data --##
 
+  last_updated:
+    command: c(I('2021-10-20'))
+
   # All sites (including those with years < min_years)
   1_fetch/out/historic_gw_site_info_unfiltered.rds:
-    command: fetch_s3(target_name, historic_unfiltered_site_info_s3_fn)
+    command: fetch_s3(target_name, historic_unfiltered_site_info_s3_fn, last_updated)
   # All data (including those with years < min_years)
   1_fetch/out/historic_gw_data_unfiltered.csv:
-    command: fetch_s3(target_name, historic_unfiltered_data_s3_fn)
+    command: fetch_s3(target_name, historic_unfiltered_data_s3_fn, last_updated)
   # This data and the quantiles are just for sites with > min_years
   1_fetch/out/historic_gw_data_filtered.csv:
-    command: fetch_s3(target_name, historic_filtered_data_s3_fn)
+    command: fetch_s3(target_name, historic_filtered_data_s3_fn, last_updated)
   
   # Only these are absolutely necessary to run the pipeline in its current 
   # state. The others will not build unless you manually build the targets.
   1_fetch/out/historic_gw_site_info_filtered.rds:
-    command: fetch_s3(target_name, historic_filtered_site_info_s3_fn)
+    command: fetch_s3(target_name, historic_filtered_site_info_s3_fn, last_updated)
   1_fetch/out/historic_gw_quantiles.csv:
-    command: fetch_s3(target_name, historic_quantiles_s3_fn)
+    command: fetch_s3(target_name, historic_quantiles_s3_fn, last_updated)
 
 ##-- GW sites and data for current viz time period --##
   

--- a/1_fetch/src/do_addl_gw_fetch.R
+++ b/1_fetch/src/do_addl_gw_fetch.R
@@ -1,0 +1,83 @@
+do_addl_gw_fetch <- function(final_target, addl_param_cds) {
+  # Special pull for just KS & just FL using `62610`. Plus, HI using `72150`.
+  # Read all about why on GitHub: https://github.com/USGS-VIZLAB/gw-conditions/issues/9
+  
+  # Creates this task makefile which then calls `do_gw_fetch()`
+  # and makes additional task makefiles for each pcode.
+  task_makefile <- '1_fetch_addl_gw_tasktable.yml'
+  
+  tasks <- unique(addl_param_cds)
+  
+  
+  identify_sites <- create_task_step(
+    step_name = 'identify_sites',
+    target_name = function(task_name, ...) {
+      sprintf('gw_sites_uv_addl_%s', task_name)
+    },
+    command = function(task_name, ...) {
+      sprintf("pull_sites_by_query(gw_quantile_site_info, I('uv'), I('%s'))", task_name)
+    }
+  )
+ 
+  download_addl_data <- create_task_step(
+    step_name = 'download_addl_data',
+    target_name = function(task_name, ...) {
+      sprintf('1_fetch/tmp/gw_data_uv_addl_%s.csv', task_name)
+    },
+    command = function(..., task_name, steps) {
+      psprintf("do_gw_fetch(",
+               "final_target = target_name,",
+               "task_makefile = I('1_fetch_tasks_addl.yml'),",
+               "gw_site_nums = %s," = steps[['identify_sites']]$target_name,
+               "gw_site_nums_obj_nm = I('%s')," = steps[['identify_sites']]$target_name,
+               "param_cd = I('%s')," = task_name,
+               "service_cd = I('uv'),",
+               "request_limit = uv_fetch_size_limit,",
+               "'1_fetch/src/do_gw_fetch.R',",
+               "'1_fetch/src/fetch_nwis.R',",
+               "include_ymls = I('%s'))" = task_makefile)
+    }
+  )
+  
+  # Create the task plan
+  task_plan <- create_task_plan(
+    task_names = tasks,
+    task_steps = list(identify_sites, download_addl_data),
+    final_steps = "download_addl_data",
+    add_complete = FALSE)
+  
+  # Create the task remakefile
+  create_task_makefile(
+    task_plan = task_plan,
+    makefile = task_makefile,
+    include = c('0_config.yml', '1_fetch.yml'),
+    sources = c('1_fetch/src/do_addl_gw_fetch.R'),
+    packages = c('tidyverse', 'dataRetrieval', 'scipiper', 'purrr'),
+    final_targets = final_target,
+    finalize_funs = 'combine_addl_gw_files',
+    as_promises = TRUE,
+    tickquote_combinee_objects = TRUE)
+  
+  # Build the tasks
+  loop_tasks(task_plan = task_plan,
+             task_makefile = task_makefile,
+             num_tries = 3, # Try a few times, there could be some internet flakiness
+             n_cores = 1) # Only one core! Don't want to overwhelm NWIS services
+  
+  # Clean up files created
+  
+  # Remove the temporary target from remake's DB; it won't necessarily be a unique  
+  #   name and we don't need it to persist, especially since killing the task yaml
+  scdel(sprintf("%s_promise", basename(final_target)), remake_file=task_makefile)
+  # Delete task makefile since it is only needed internally for this function and  
+  #   not needed at all once loop_tasks is complete. Also delete temporary files
+  #   saved in order to decouple task makefile from `remake.yml`.
+  file.remove(task_makefile)
+  
+}
+
+combine_addl_gw_files <- function(target_name, ...) {
+  purrr::map(list(...), function(fn) read_csv(fn)) %>% 
+    bind_rows() %>% 
+    readr::write_csv(target_name)
+}

--- a/1_fetch/src/do_gw_fetch.R
+++ b/1_fetch/src/do_gw_fetch.R
@@ -1,5 +1,5 @@
 do_gw_fetch <- function(final_target, task_makefile, gw_site_nums, gw_site_nums_obj_nm, 
-                        param_cd_obj_nm, service_cd, request_limit, ...) {
+                        param_cd, service_cd, request_limit, ..., include_ymls = NULL) {
   
   # Number indicating how many sites to include per dataRetrieval request to prevent
   # errors from requesting too much at once. More relevant for surface water requests.
@@ -43,7 +43,7 @@ do_gw_fetch <- function(final_target, task_makefile, gw_site_nums, gw_site_nums_
                "gw_sites = %s," = steps[["subset_sites"]]$target_name,
                "start_date = viz_start_date,",
                "end_date = viz_end_date,",
-               "param_cd = %s)" = param_cd_obj_nm)
+               "param_cd = I('%s'))" = param_cd)
     }
   )
   
@@ -72,10 +72,11 @@ do_gw_fetch <- function(final_target, task_makefile, gw_site_nums, gw_site_nums_
     add_complete = FALSE)
   
   # Create the task remakefile
+  if(is.null(include_ymls)) include_ymls <- c('0_config.yml', '1_fetch.yml') # include_ymls is NULL by default
   create_task_makefile(
     task_plan = task_plan,
     makefile = task_makefile,
-    include = c('0_config.yml', '1_fetch.yml'),
+    include = include_ymls,
     sources = c(...),
     packages = c('tidyverse', 'dataRetrieval', 'scipiper', 'feather', 'purrr'),
     final_targets = final_target,

--- a/1_fetch/src/fetch_s3.R
+++ b/1_fetch/src/fetch_s3.R
@@ -1,6 +1,7 @@
 # s3_get will only download and save the file exactly in the filepath it appears on S3
 # So, this function uses S3_get but then moves the file where we want it
-fetch_s3 <- function(target_name, s3_file) {
+fetch_s3 <- function(target_name, s3_file, dummy_date) {
+  # `dummy_date` is only used to force a rebuild
   s3_config <- yaml::yaml.load_file(getOption("scipiper.s3_config_file"))
   aws.signature::use_credentials(profile = s3_config$profile)
   aws.s3::save_object(object = s3_file, bucket = s3_config$bucket, 

--- a/1_fetch/src/fetch_usa_bbox.R
+++ b/1_fetch/src/fetch_usa_bbox.R
@@ -1,0 +1,41 @@
+
+# Default is to use all US states and territories
+# Specify a specific region by passing in a vector of states to `states`
+fetch_usa_bbox <- function(states = NULL, conus_only = FALSE, states_only = FALSE) {
+  # This was a useful resource: https://anthonylouisdagostino.com/bounding-boxes-for-all-us-states/
+  # Must be west longitude, south latitude, east longitude, and then north latitude
+  
+  readr::read_csv("https://gist.githubusercontent.com/a8dx/2340f9527af64f8ef8439366de981168/raw/81d876daea10eab5c2675811c39bcd18a79a9212/US_State_Bounding_Boxes.csv",
+                  col_types = cols()) %>% 
+    {
+      # If `states` is provided, just use that
+      if(!is.null(states)) 
+        filter(., STUSPS %in% states) 
+      else 
+        
+      {if(conus_only) filter(., !STUSPS %in% c(
+        "AK", # Alaska (xmin = -179 & xmax = +179)
+        "HI", # Hawaii
+        "AS", # American Samoa
+        "GU", # Guam
+        "MP", # Commonwealth of the Northern Mariana Islands
+        "PR", # Puerto Rico
+        "VI"  # U.S. Virgin Islands
+      )) else .} %>%
+        {if(states_only) filter(., !STUSPS %in% c(
+          "AS", # American Samoa
+          "GU", # Guam
+          "MP", # Commonwealth of the Northern Mariana Islands
+          "PR", # Puerto Rico
+          "VI"  # U.S. Virgin Islands
+        )) else .}
+        
+      } %>% 
+    summarize(
+      bbox_xmin = min(xmin),
+      bbox_ymin = min(ymin),
+      bbox_xmax = max(xmax),
+      bbox_ymax = max(ymax)
+    ) %>% t() %>% as.vector()
+    
+}


### PR DESCRIPTION
This is still building locally, but maybe it will finish and get pushed up while I am out?? I also snuck in the change to expand the dates to Oct 2020 for the visualization component. This DOES NOT add the actual new states to the SVG map. Take a look at gages-through-the-ages for an example (there is [some kind of class magic](https://github.com/usgs-makerspace/gages-through-the-ages/blob/master/data_processing_pipeline/2_process/src/process_state_svg.R#L43) 🧙 that happens if it is an exterior state). There is also [a half-baked example of shifting `sf` in R](https://github.com/USGS-VIZLAB/viz-scratch/tree/main/shift_oconus_states) before it becomes SVG but it only works for polygons right now, not points.