### PR TITLE
Fix dependency bug

### DIFF
--- a/1_fetch.yml
+++ b/1_fetch.yml
@@ -96,10 +96,10 @@ targets:
   1_fetch/out/gw_data_uv_addl.csv:
     command: do_addl_gw_fetch(
       final_target = target_name,
-      addl_param_cds = addl_gw_param_cds)
+      addl_param_cds = addl_gw_param_cds,
+      viz_start_date = viz_start_date,
+      viz_end_date = viz_end_date)
     depends:
-      - viz_start_date
-      - viz_end_date
       - '1_fetch/src/fetch_nwis.R'
 
   # Combine all data

--- a/1_fetch/src/do_addl_gw_fetch.R
+++ b/1_fetch/src/do_addl_gw_fetch.R
@@ -1,4 +1,4 @@
-do_addl_gw_fetch <- function(final_target, addl_param_cds) {
+do_addl_gw_fetch <- function(final_target, addl_param_cds, viz_start_date, viz_end_date) {
   # Special pull for just KS & just FL using `62610`. Plus, HI using `72150`.
   # Read all about why on GitHub: https://github.com/USGS-VIZLAB/gw-conditions/issues/9
   
@@ -38,7 +38,8 @@ do_addl_gw_fetch <- function(final_target, addl_param_cds) {
                "include_ymls = I('%s')," = task_makefile,
                "gw_site_tz_xwalk_nm = I('gw_quantile_site_tz_xwalk'),",
                "filename_qualifier = I('_addl_%s'))" = task_name)
-    }
+    },
+    depends = c("viz_start_date", "viz_end_date")
   )
   
   # Create the task plan

--- a/3_visualize/out/gw-conditions-daily-proportions-s3copy.ind
+++ b/3_visualize/out/gw-conditions-daily-proportions-s3copy.ind
@@ -1,2 +1,2 @@
-hash: 4dbbfa5e2ecb775788530aa799885e4a
+hash: 7e98eb082cb2abda37fcd663230f1940
 

--- a/3_visualize/out/gw-conditions-peaks-timeseries-s3copy.ind
+++ b/3_visualize/out/gw-conditions-peaks-timeseries-s3copy.ind
@@ -1,2 +1,2 @@
-hash: a1d1ba80ff6d63058fbdd44e3e02c21f
+hash: 27af0faa6ba9d1aa69ced5d194c1376b
 

--- a/visualizations/data/gw-conditions-daily-proportions-live.csv.ind
+++ b/visualizations/data/gw-conditions-daily-proportions-live.csv.ind
@@ -1,2 +1,2 @@
-hash: 4dbbfa5e2ecb775788530aa799885e4a
+hash: 7e98eb082cb2abda37fcd663230f1940
 

--- a/visualizations/data/gw-conditions-daily-proportions.csv.ind
+++ b/visualizations/data/gw-conditions-daily-proportions.csv.ind
@@ -1,2 +1,2 @@
-hash: 4dbbfa5e2ecb775788530aa799885e4a
+hash: 7e98eb082cb2abda37fcd663230f1940
 

--- a/visualizations/data/gw-conditions-peaks-timeseries-live.csv.ind
+++ b/visualizations/data/gw-conditions-peaks-timeseries-live.csv.ind
@@ -1,2 +1,2 @@
-hash: a1d1ba80ff6d63058fbdd44e3e02c21f
+hash: 27af0faa6ba9d1aa69ced5d194c1376b
 

--- a/visualizations/data/gw-conditions-peaks-timeseries.csv.ind
+++ b/visualizations/data/gw-conditions-peaks-timeseries.csv.ind
@@ -1,2 +1,2 @@
-hash: a1d1ba80ff6d63058fbdd44e3e02c21f
+hash: 27af0faa6ba9d1aa69ced5d194c1376b
 


### PR DESCRIPTION
This PR fixes a bug in the 'additional' data pull that pulls data for KS, FL, and HI, building `'1_fetch/out/gw_data_uv_addl.csv'`.

### The bug
In the current pipeline, when `viz_start_date` and/or `viz_end_date` are changed, the 'additional' groundwater tasks are not re-run, so data is not pulled for the new time period. 

I noticed this after re-running the pipeline for calendar year 2022 (#82). No new data was pulled for FL, KS, or HI, so data for those states ended on 10/31/22, the _previous_ `viz_end_date` from when I'd built the water year 2022 viz.

### Context

The `'1_fetch/out/gw_data_uv_addl.csv'` target is built using a nested set of task tables. The outer task table, `'1_fetch_addl_gw_tasktable.yml'` sets up two calls to `do_gw_fetch()`, which generates another task table, `'1_fetch_tasks_addl.yml'`, for each additional parameter code. 

In theory, these tasks should all be re-run when `viz_start_date` and/or `viz_end_date` are updated, as is the case with the main gw tasks. Previously, `viz_start_date` and `viz_end_date` were specified as [dependencies of the summary csv](https://github.com/USGS-VIZLAB/gw-conditions/blob/main/1_fetch.yml#L96-L103). However, as those variables were not actually included as arguments in the calls to `do_gw_fetch` in `1_fetch_addl_gw_tasktable.yml`, those calls were _not_ dependent on those variables, and were not seen as out of date by `scipiper` if either `viz_start_date` or `viz_end_date` changed.

### The fix
I've updated the target recipe in `'1_fetch.R'` for `'1_fetch/out/gw_data_uv_addl.csv'` to pass `viz_start_date` and `viz_end_date` as arguments to `do_addl_gw_fetch()`. Then, within that function, I specify those two variables as dependencies for the `do_gw_fetch()` step in the task table. Now, in `'1_fetch_addl_gw_tasktable.yml'`, the calls to `do_gw_fetch()` state that dependency, and are re-run if either `viz_start_date` or `viz_end_date` change:
<img width="416" alt="Dependency" src="https://user-images.githubusercontent.com/54007288/212951648-595d4f00-fe28-4ce8-948d-4ddd1d559753.PNG">
