### PR TITLE
Fix mobile map

### DIFF
--- a/src/components/GWL.vue
+++ b/src/components/GWL.vue
@@ -717,6 +717,8 @@ section {
   align-items: center;
   svg.map {
     max-height: 68vh;
+    width: 100%;
+    height: 100%;
   }
   svg.map.labels {
     position: absolute;


### PR DESCRIPTION
Try setting svg width and height o 100% since also not showing on safari 