### PR TITLE
Fix mobile map

### DIFF
--- a/src/assets/gw-conditions-labels-map.svg
+++ b/src/assets/gw-conditions-labels-map.svg
@@ -1,7 +1,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 1000 700" preserveAspectRatio="xMidYMid meet" version="1.1" aria-labelledby="mapTitleID mapDescID" role="img">
-  <g id="label-islands" class="map-label" transform="translate(-40, -45) scale(0.95 1)">
+  <g id="label-islands" class="map-label" transform="translate(-50, -25) scale(0.95 1)">
     <path d="M1120.57,345.28H986.12L905.35,447.51l30.77,61.36v98.5" class="line-islands" />
     <line x1="1120.57" y1="447.51" x2="905.35" y2="447.51" class="line-islands" />
     <polyline points="23.19 260.82 159.41 260.82 229.82 410.89 129.48 543.08 23.19 543.08" class="line-islands" />

--- a/src/components/GWL.vue
+++ b/src/components/GWL.vue
@@ -717,6 +717,8 @@ section {
   align-items: center;
   svg.map {
     max-height: 68vh;
+    width: 100%;
+    height: 100%;
   }
   svg.map.labels {
     position: absolute;

--- a/src/components/GWL.vue
+++ b/src/components/GWL.vue
@@ -14,26 +14,13 @@
       <!--   <caption id="caption-gwl">Daily groundwater levels</caption> -->
       </div>
       <div id="map-container">
-        <svg 
-          id="map_svg" 
-          xmlns="http://www.w3.org/2000/svg" 
-          xmlns:xlink="http://www.w3.org/1999/xlink" 
-          viewBox="0 0 1000 700"
-          preserveAspectRatio="xMidYMid meet" 
-          version="1.1" 
-          role="img"
-          class="map"
-        >
           <GWLmap
             id="map_gwl"
             class="map"
           />
-          <g transform="translate(-10, 20)">
-            <mapLabels 
-              class="map"
-            />
-          </g>
-        </svg>
+          <mapLabels 
+            class="map labels"
+          />
       </div>
       <div id="legend-container">
         <Legend />
@@ -720,7 +707,7 @@ section {
       }
 
 }
-#map-container{
+#map-container {
   grid-area: map;
   padding: 0rem;
   padding-bottom: 0px;
@@ -731,7 +718,11 @@ section {
   svg.map {
     max-height: 68vh;
   }
+  svg.map.labels {
+    position: absolute;
+  }
 }
+
 #line-container {
   grid-area: line;
   width: 100%;

--- a/src/components/GWL.vue
+++ b/src/components/GWL.vue
@@ -717,6 +717,7 @@ section {
   align-items: center;
   svg.map {
     max-height: 68vh;
+    max-width: 98vw;
     width: 100%;
     height: 100%;
   }


### PR DESCRIPTION
Merging in this branch w/o review because the live site is not displaying the map in Safari on desktop or in any browser on mobile, and these changes have all been tested by pushing to beta from the `fix_mobile_map` branch

The changes I made were to:
* Change how the svg map and svg map labels were layered (as individual overlaid components in the div rather than nested within an svg within the div)
* Moved the transformation on the map labels svg into the component
* Set the svg map and svg map labels width and height to 100%
* Set a width limit of 98vw for the map